### PR TITLE
Add Python metadata to support build isolation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.h *.cc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ['setuptools']
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This is so that `python3 -m build .` can work.