### PR TITLE
setup.py: Make sure an 'sdist' can be built even if no 4ti2 is found

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,9 +72,8 @@ if check_4ti2_prec("HAVE_GMP") == "no":
     modules_cc.remove(modulegmp)
     print("Py4ti2gmp will not be built")
 
-if len(modules_cc)!=0:
-    setup(
-        py_modules = modules_py, 
-        ext_modules = modules_cc,
-        package_data = {'': [ "COPYING", "GPLv2", "README.md" ] }
-    )
+setup(
+    py_modules = modules_py, 
+    ext_modules = modules_cc,
+    package_data = {'': [ "COPYING", "GPLv2", "README.md" ] }
+)


### PR DESCRIPTION
Fixes error seen in https://github.com/passagemath/Py4ti2/actions/runs/15278188079/job/42969982259#step:4:46